### PR TITLE
Proper teardown on call leave

### DIFF
--- a/src/call.js
+++ b/src/call.js
@@ -2,6 +2,7 @@ import {
   removeAllCursors,
   removeCursor,
   startCursorListener,
+  stopCursorListener,
   updateRemoteCursor,
 } from './cursor.js';
 import { showEntry } from './scenes.js';
@@ -32,6 +33,7 @@ export default function joinCall(roomURL) {
       startCursorListener(callback);
     })
     .on('left-meeting', () => {
+      stopCursorListener();
       removeAllCursors();
       showEntry();
     })

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -19,17 +19,18 @@ export function updateRemoteCursor(userID, userName, posX, posY) {
 export function startCursorListener(callback) {
   contentElement = document.getElementById('content');
   const scrollElement = document.getElementById('scroll');
-  scrollElement.addEventListener(
-    'mousemove',
-    (e) => {
-      clearTimeout(mouseStopTimeout);
+  scrollElement.onmousemove = (e) => {
+    clearTimeout(mouseStopTimeout);
 
-      mouseStopTimeout = setTimeout((_) => {
-        sendData(e, callback);
-      }, 100);
-    },
-    false
-  );
+    mouseStopTimeout = setTimeout((_) => {
+      sendData(e, callback);
+    }, 100);
+  };
+}
+
+export function stopCursorListener() {
+  const scrollElement = document.getElementById('scroll');
+  scrollElement.onmousemove = null;
 }
 
 export function removeCursor(userID) {

--- a/src/scenes.js
+++ b/src/scenes.js
@@ -6,8 +6,10 @@ export function showCall() {
 }
 
 export function showEntry() {
-  const callElement = document.getElementById('inCall');
+  const inCallElement = document.getElementById('inCall');
   const entryElement = document.getElementById('entry');
+  const callElement = document.getElementById('call');
+  callElement.innerText = '';
   entryElement.classList.remove('hidden');
-  callElement.classList.add('hidden');
+  inCallElement.classList.add('hidden');
 }


### PR DESCRIPTION
When staging the cursor sharing post I realized I've missed a couple of cleanup steps. This PR adds them:

* Instead of adding a new event listener each time we start cursor sharing, just set `onmousemove`, ensuring we only ever have one.
* Set `onmousemove` to null when user is leaving the call - no point handling mousemove events if they're not in a call anymore.
* Clear the call container when leaving the call (to make sure the user doesn't see multiple call frames on rejoin)